### PR TITLE
Small fixes to the USA lists

### DIFF
--- a/google-10000-english-usa-no-swears-medium.txt
+++ b/google-10000-english-usa-no-swears-medium.txt
@@ -427,7 +427,6 @@ final
 adult
 tickets
 thing
-centre
 cheap
 finance
 minutes
@@ -2693,7 +2692,6 @@ grown
 polish
 lovely
 extras
-centres
 jerry
 clause
 smile

--- a/google-10000-english-usa-no-swears.txt
+++ b/google-10000-english-usa-no-swears.txt
@@ -818,7 +818,6 @@ final
 adult
 tickets
 thing
-centre
 requirements
 via
 cheap
@@ -4783,7 +4782,6 @@ polish
 lovely
 extras
 gm
-centres
 jerry
 clause
 smile

--- a/google-10000-english-usa.txt
+++ b/google-10000-english-usa.txt
@@ -2738,7 +2738,6 @@ infrastructure
 exclusive
 seat
 concerns
-color
 vendor
 originally
 intel
@@ -3159,7 +3158,6 @@ indicate
 blonde
 ab
 proceedings
-favorite
 transmission
 anderson
 utc
@@ -3522,7 +3520,6 @@ lg
 swiss
 sarah
 clark
-labor
 hate
 terminal
 publishers
@@ -3720,7 +3717,6 @@ writers
 marks
 flexible
 loved
-favorites
 mapping
 numerous
 relatively
@@ -4755,7 +4751,6 @@ venue
 athletic
 thermal
 essays
-behavior
 vital
 telling
 fairly
@@ -6853,7 +6848,6 @@ martial
 males
 victorian
 retain
-colors
 execute
 tunnel
 genres
@@ -7461,7 +7455,6 @@ medal
 paperbacks
 coaches
 vessels
-harbor
 walks
 sucks
 sol
@@ -8644,7 +8637,6 @@ sewing
 consistency
 collectors
 conclude
-recognized
 munich
 oman
 celebs
@@ -8898,7 +8890,6 @@ firewire
 mods
 nextel
 framing
-organized
 musician
 blocking
 rwanda
@@ -9218,7 +9209,6 @@ peas
 dosage
 receivers
 urls
-customize
 disposition
 variance
 navigator
@@ -9803,7 +9793,6 @@ lu
 wagon
 barbie
 dat
-favor
 soa
 knock
 urge

--- a/google-10000-english-usa.txt
+++ b/google-10000-english-usa.txt
@@ -821,7 +821,6 @@ final
 adult
 tickets
 thing
-centre
 requirements
 via
 cheap
@@ -4836,7 +4835,6 @@ polish
 lovely
 extras
 gm
-centres
 jerry
 clause
 smile


### PR DESCRIPTION
Some conversions resulted in duplicate words, and one British spelling that I noticed was missed. In most cases the corrections exist in some list variants but not all of them.